### PR TITLE
api/firmware: fix reset

### DIFF
--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -149,15 +149,20 @@ func (device *Device) Version() *semver.SemVer {
 // Init initializes the device. It changes the status to StatusRequireAppUpgrade of needed,
 // otherwise performs the attestation check, unlock, and noise pairing.
 func (device *Device) Init() error {
+	device.attestation = false
+	device.deviceNoiseStaticPubkey = nil
+	device.channelHash = ""
+	device.channelHashAppVerified = false
+	device.channelHashDeviceVerified = false
+	device.sendCipher = nil
+	device.receiveCipher = nil
+	device.changeStatus(StatusConnected)
+
 	if device.version.AtLeast(lowestNonSupportedFirmwareVersion) {
 		device.changeStatus(StatusRequireAppUpgrade)
 		return nil
 	}
 
-	return device.init()
-}
-
-func (device *Device) init() error {
 	if device.version.AtLeast(semver.NewSemVer(2, 0, 0)) {
 		attestation, err := device.performAttestation()
 		if err != nil {
@@ -710,8 +715,7 @@ func (device *Device) Reset() error {
 	if err != nil {
 		return err
 	}
-	device.changeStatus(StatusConnected)
-	return device.init()
+	return device.Init()
 }
 
 // ShowMnemonic lets the user export the bip39 mnemonic phrase on the device.


### PR DESCRIPTION
After Reset(), all data should be reset. This especially fixes the
issue where channelHashDeviceVerified was true after the reset.