### PR TITLE
api/firmware: fix reboot regression

### DIFF
--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -38,7 +38,6 @@ var (
 
 // Communication contains functions needed to communicate with the device.
 type Communication interface {
-	SendFrame(string) error
 	Query([]byte) ([]byte, error)
 	Close()
 }

--- a/api/firmware/mocks/mocks.go
+++ b/api/firmware/mocks/mocks.go
@@ -19,14 +19,8 @@ import "github.com/flynn/noise"
 
 // Communication is a mock implementation of firmware.Communication.
 type Communication struct {
-	MockSendFrame func(msg string) error
-	MockQuery     func([]byte) ([]byte, error)
-	MockClose     func()
-}
-
-// SendFrame implements firmware.Communication.
-func (communication *Communication) SendFrame(msg string) error {
-	return communication.MockSendFrame(msg)
+	MockQuery func([]byte) ([]byte, error)
+	MockClose func()
 }
 
 // Query implements firmware.Query.

--- a/api/firmware/system.go
+++ b/api/firmware/system.go
@@ -105,11 +105,14 @@ func (device *Device) reboot() error {
 			Reboot: &messages.RebootRequest{},
 		},
 	}
-	requestBytesEncrypted, err := device.requestBytesEncrypted(request)
-	if err != nil {
+
+	_, err := device.query(request)
+	// We only return bb02 errors. Otherwise we assume it's an IO error (read failed) due to the
+	// reboot.
+	if _, ok := errp.Cause(err).(*Error); ok {
 		return err
 	}
-	return device.communication.SendFrame(string(requestBytesEncrypted))
+	return nil
 }
 
 // UpgradeFirmware reboots into the bootloader so a firmware can be flashed.


### PR DESCRIPTION
The call needs to be blocking due to the dialog on the device.