### PR TITLE
api/firmware: add noise handhshake framing and response framing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,11 +65,6 @@ linters-settings:
     min-len: 3
     # minimal occurrences count to trigger, 3 by default
     min-occurrences: 3
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
@@ -97,6 +92,7 @@ linters:
     - dupl
     - wsl
     - interfacer
+    - misspell
   disable-all: false
 
 issues:

--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -33,7 +33,7 @@ var (
 	lowestSupportedFirmwareVersion                   = semver.NewSemVer(6, 0, 0)
 	lowestSupportedFirmwareVersionBTCOnly            = semver.NewSemVer(6, 0, 0)
 	lowestSupportedFirmwareVersionBitBoxBaseStandard = semver.NewSemVer(4, 3, 0)
-	lowestNonSupportedFirmwareVersion                = semver.NewSemVer(7, 0, 0)
+	lowestNonSupportedFirmwareVersion                = semver.NewSemVer(8, 0, 0)
 )
 
 // Communication contains functions needed to communicate with the device.
@@ -64,6 +64,7 @@ type Logger interface {
 
 const (
 	opICanHasHandShaek          = "h"
+	opHerComezTehHandshaek      = "H"
 	opICanHasPairinVerificashun = "v"
 	opNoiseMsg                  = "n"
 	opAttestation               = "a"
@@ -308,10 +309,23 @@ func (device *Device) query(request proto.Message) (*messages.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(responseBytes) == 0 {
+		return nil, errp.New("noise communication failed: empty response")
+	}
+	if device.version.AtLeast(semver.NewSemVer(7, 0, 0)) {
+		// From v7.0.0, encrypted noise responses are framed
+		if string(responseBytes[:1]) != responseSuccess {
+			return nil, errp.New("handshake query failed")
+		}
+		responseBytes = responseBytes[1:]
+	}
+
 	responseBytesDecrypted, err := device.receiveCipher.Decrypt(nil, nil, responseBytes)
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
+
 	response := &messages.Response{}
 	if err := proto.Unmarshal(responseBytesDecrypted, response); err != nil {
 		return nil, errp.WithStack(err)

--- a/api/firmware/pairing.go
+++ b/api/firmware/pairing.go
@@ -21,8 +21,24 @@ import (
 
 	"github.com/digitalbitbox/bitbox02-api-go/api/common"
 	"github.com/digitalbitbox/bitbox02-api-go/util/errp"
+	"github.com/digitalbitbox/bitbox02-api-go/util/semver"
 	"github.com/flynn/noise"
 )
+
+func (device *Device) handshakeQuery(msg []byte) ([]byte, error) {
+	if device.version.AtLeast(semver.NewSemVer(7, 0, 0)) {
+		// From v7.0.0. the handshake request and response are framed.
+		response, err := device.communication.Query(append([]byte(opHerComezTehHandshaek), msg...))
+		if err != nil {
+			return nil, err
+		}
+		if len(response) == 0 || string(response[:1]) != responseSuccess {
+			return nil, errp.New("handshake query failed")
+		}
+		return response[1:], nil
+	}
+	return device.communication.Query(msg)
+}
 
 func (device *Device) pair() error {
 	cipherSuite := noise.NewCipherSuite(noise.DH25519, noise.CipherChaChaPoly, noise.HashSHA256)
@@ -63,7 +79,7 @@ func (device *Device) pair() error {
 	if err != nil {
 		panic(err)
 	}
-	responseBytes, err = device.communication.Query(msg)
+	responseBytes, err = device.handshakeQuery(msg)
 	if err != nil {
 		return err
 	}
@@ -75,7 +91,7 @@ func (device *Device) pair() error {
 	if err != nil {
 		panic(err)
 	}
-	responseBytes, err = device.communication.Query(msg)
+	responseBytes, err = device.handshakeQuery(msg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Since v7.0.0, the two initial noise handshake messages are framed:
request is prepended with 'H', response is prepended with
OP_STATUS_SUCCESS/OP_STATUS_FAILURE.

Since v4.0.0, encrypted noise message requests were framed with
OP_NOISE_MSG, but since v7.0.0, the response is also framed with
OP_STATUS_SUCCESS/OP_STATUS_FAILURE.