### PR TITLE
api/firmware: min version must be 6.1.0

### DIFF
--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -30,8 +30,8 @@ import (
 //go:generate sh -c "protoc --proto_path=messages/ --go_out='import_path=messages,paths=source_relative:messages' messages/*.proto"
 
 var (
-	lowestSupportedFirmwareVersion                   = semver.NewSemVer(6, 0, 0)
-	lowestSupportedFirmwareVersionBTCOnly            = semver.NewSemVer(6, 0, 0)
+	lowestSupportedFirmwareVersion                   = semver.NewSemVer(6, 1, 0)
+	lowestSupportedFirmwareVersionBTCOnly            = semver.NewSemVer(6, 1, 0)
 	lowestSupportedFirmwareVersionBitBoxBaseStandard = semver.NewSemVer(4, 3, 0)
 	lowestNonSupportedFirmwareVersion                = semver.NewSemVer(7, 0, 0)
 )


### PR DESCRIPTION
Contains a required bugfix for MEW and a required new api call for
Electrum (ElectrumEncryptionKey).