### PR TITLE
ci: run on both go1.14 and go1.12 for GopherJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ os:
   - linux
 
 language: go
-go: 1.13.x
+go:
+  - 1.12.x # need this due to GopherJS being stuck on go1.12
+  - 1.14.x
 
 addons:
   apt:


### PR DESCRIPTION
GopherJS is stuck on go1.12 and because we use it to generate api-js,
need to ensure this still compiles.

The other one, go1.14, is to make sure we will be able to build it when
GopherJS is finally unstuck.