### PR TITLE
firmware: add attestation keys

### DIFF
--- a/api/firmware/attestation.go
+++ b/api/firmware/attestation.go
@@ -65,6 +65,12 @@ var attestationPubkeys = map[string]attestationPubkey{
 	"fa077dc3d0caea63d8a2a7ba0392560b76041001e3ba3af9655423ff457b9d1e": {
 		pubkeyHex: "049f1b7180014b6de60d41f16a3c0a37b20146585e4884960249d30f3cd68c74d04420d0cedef5719d6b1529b085ecd534fa6c1690be5eb1b3331bc57b5db224dc",
 	},
+	"e00da42fea5ae884fcfb351b62b6ca4e64a94cde155164fad83f44732c51a844": {
+		pubkeyHex: "04adaa011a4ced11310728abb64f09636267ce0b05782da6d3eeaf987cec7c64f279ad55327184f9e5b4a1e53089b31bcc65032dad7205325f41ed3d9fdfba1f88",
+	},
+	"e1295cbb22e3ab5479b2be728f9b6899b509295beecab93c42b24f8f0a620c9c": {
+		pubkeyHex: "044a70e663d7fe5fe0d4cbbb752883e35222b8d7d7bffdaa8d591995d1252528a4e9a3e4d5220d485021728b3cdad4fccc681a6ddeea8e2f7c55b4acde8d53573d",
+	},
 }
 
 // performAttestation sends a random challenge and verifies that the response can be verified with

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -199,6 +199,12 @@ func main() {
 	const bitboxCMD = 0x80 + 0x40 + 0x01
 	comm := u2fhid.NewCommunication(hidDevice, bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
+	device.SetOnEvent(func(ev firmware.Event, meta interface{}) {
+		if ev == firmware.EventAttestationCheckDone {
+			attestation := device.Attestation()
+			fmt.Println("Attestation check:", *attestation)
+		}
+	})
 	device.Init()
 	device.ChannelHashVerify(true)
 


### PR DESCRIPTION
According to https://github.com/digitalbitbox/bitbox02-firmware/pull/882