### PR TITLE
firmware: added support to Goerli ETH testnet.

### DIFF
--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -332,10 +332,12 @@ func (device *Device) Product() common.Product {
 }
 
 // SupportsETH returns true if ETH is supported by the device api.
-// coinCode is eth/teth/reth or eth-erc20-xyz, ...
 func (device *Device) SupportsETH(chainID uint64) bool {
 	if *device.product != common.ProductBitBox02Multi {
 		return false
+	}
+	if device.version.AtLeast(semver.NewSemVer(9, 10, 0)) {
+		return true
 	}
 	if device.version.AtLeast(semver.NewSemVer(4, 0, 0)) {
 		switch chainID {


### PR DESCRIPTION
This adds Goerli testnet chain ID between those which are supported, starting from FW version 9.10.0.