### PR TITLE
api/firwmare/mnemonic: log when passphrase is enabled/disabled

### DIFF
--- a/api/firmware/mnemonic.go
+++ b/api/firmware/mnemonic.go
@@ -15,6 +15,7 @@
 package firmware
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/digitalbitbox/bitbox02-api-go/api/firmware/messages"
@@ -81,5 +82,6 @@ func (device *Device) SetMnemonicPassphraseEnabled(enabled bool) error {
 	if !ok {
 		return errp.New("unexpected response")
 	}
+	device.log.Info(fmt.Sprintf("SetMnemonicPassphraseEnabled=%v successfully finished", enabled))
 	return nil
 }


### PR DESCRIPTION
This will help with determining if someone used the passphrase, which is often the cause of "missing funds" (when using the wrong passphrase).