### PR TITLE
communication/u2fhid: prepend 0 byte to packet

### DIFF
--- a/communication/u2fhid/u2fhid.go
+++ b/communication/u2fhid/u2fhid.go
@@ -166,8 +166,9 @@ func (communication *Communication) readFrame() ([]byte, error) {
 	if readLen < 7 {
 		return nil, errp.New("expected minimum read length of 7")
 	}
-	if read[0] != 0xff || read[1] != 0 || read[2] != 0 || read[3] != 0 {
-		return nil, errp.Newf("USB command ID mismatch %d %d %d %d", read[0], read[1], read[2], read[3])
+	replyCid := binary.BigEndian.Uint32(read[:4])
+	if replyCid != cid {
+		return nil, errp.Newf("USB command ID mismatch, %v != %v", cid, replyCid)
 	}
 	if read[4] != communication.cmd {
 		return nil, errp.Newf("USB command frame mismatch (%d, expected %d)", read[4], communication.cmd)


### PR DESCRIPTION
If a USB packet starts with a zero byte, that byte will be stripped by the C USB library (i.e. signal11 on Linux), leading to a broken package.

We only need to add it if not on Windows, as karalabel/usb prepends this zero byte already for Windows (I think this is a bug in karalabe/usb and karalabe/hid, which didn't consider that a packet could start with a zero byte right after the report ID).

Currently we don't observe a bug because the first byte in each packet is the `cid` (channel identifier), which is harddcoded to `0xff000000`. If we start using a random CID, and it starts with a zero byte, the packet will be corrupted and the BitBox02 will not be able to parse it.

The same fix was also added to the bitbox01 in the BitBoxApp (https://github.com/digitalbitbox/bitbox-wallet-app/blob/bd70f6c400268355cee94891397447796f02fbde/backend/devices/bitbox/communication.go#L235-L241), where it was crucial because packets in the bitbox01 are padded with zero bytes to the left.