### PR TITLE
communication/u2fhid: don't hardcode CID check in response

### DIFF
--- a/communication/u2fhid/u2fhid.go
+++ b/communication/u2fhid/u2fhid.go
@@ -153,8 +153,9 @@ func (communication *Communication) readFrame() ([]byte, error) {
 	if readLen < 7 {
 		return nil, errp.New("expected minimum read length of 7")
 	}
-	if read[0] != 0xff || read[1] != 0 || read[2] != 0 || read[3] != 0 {
-		return nil, errp.Newf("USB command ID mismatch %d %d %d %d", read[0], read[1], read[2], read[3])
+	replyCid := binary.BigEndian.Uint32(read[:4])
+	if replyCid != cid {
+		return nil, errp.Newf("USB command ID mismatch, %v != %v", cid, replyCid)
 	}
 	if read[4] != communication.cmd {
 		return nil, errp.Newf("USB command frame mismatch (%d, expected %d)", read[4], communication.cmd)


### PR DESCRIPTION
The CID in the response is compared against the hardcoded 0xff000000 CID. It should however parse and compare it to the const `cid`. This allows us to change the CID (i.e. make it random) and not break parsing.