### PR TITLE
.github/workflows/ci.yml: update to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,17 @@
 name: ci
 on: [push, pull_request]
 env:
-  GO_VERSION: "^1.16"
-  GOLANGCI_LINT_VERSION: "v1.46.1"
+  GO_VERSION: "^1.20"
+  GOLANGCI_LINT_VERSION: "v1.52.2"
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Enable caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Increment cache number to invalidate.
           key: ${{runner.os}}-cache-1
@@ -22,7 +22,7 @@ jobs:
             ~/.cache/go-build
             ~/.cache/golangci-lint
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{env.GO_VERSION}}
       # Keep the linter version and its config in .golangci.yml in sync with the app repo at
@@ -34,12 +34,12 @@ jobs:
       - name: Lint
         run: ~/golangci-lint run --skip-dirs=cmd/playground
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Enable caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Increment cache number to invalidate.
           key: ${{runner.os}}-cache-1
@@ -48,7 +48,7 @@ jobs:
             ~/.cache/go-build
             ~/.cache/golangci-lint
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Test
@@ -56,12 +56,12 @@ jobs:
           go version
           go test ./...
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Enable caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Increment cache number to invalidate.
           key: ${{runner.os}}-cache-1
@@ -70,7 +70,7 @@ jobs:
             ~/.cache/go-build
             ~/.cache/golangci-lint
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,6 +127,14 @@ linters:
     - forbidigo
     - makezero
     - nolintlint
+    - gocyclo
+    - nosnakecase
+    - interfacebloat
+    - revive
+    - musttag
+    - structcheck
+    - deadcode
+    - varcheck
   disable-all: false
 
 issues:

--- a/api/bootloader/device.go
+++ b/api/bootloader/device.go
@@ -310,7 +310,7 @@ func (device *Device) UpgradeFirmware(firmware []byte) error {
 	return device.Reboot()
 }
 
-// Erased returns true if the the device contains no firmware.
+// Erased returns true if the device contains no firmware.
 func (device *Device) Erased() (bool, error) {
 	// We check by comparing the device reported firmware hash. If erased, the firmware is all
 	// '\xFF'.

--- a/api/firmware/device.go
+++ b/api/firmware/device.go
@@ -117,10 +117,12 @@ type DeviceInfo struct {
 
 // NewDevice creates a new instance of Device.
 // version:
-//   Can be given if known at the time of instantiation, e.g. by parsing the USB HID product string.
-//   It must be provided if the version could be less than 4.3.0.
-//   If nil, the version will be queried from the device using the OP_INFO api endpoint. Do this
-//   when you are sure the firmware version is bigger or equal to 4.3.0.
+//
+//	Can be given if known at the time of instantiation, e.g. by parsing the USB HID product string.
+//	It must be provided if the version could be less than 4.3.0.
+//	If nil, the version will be queried from the device using the OP_INFO api endpoint. Do this
+//	when you are sure the firmware version is bigger or equal to 4.3.0.
+//
 // product: same deal as with the version, after 4.3.0 it can be inferred by OP_INFO.
 func NewDevice(
 	version *semver.SemVer,

--- a/api/firmware/event.go
+++ b/api/firmware/event.go
@@ -26,7 +26,7 @@ const (
 	// EventStatusChanged is fired when the status changes. Check the status using Status().
 	EventStatusChanged Event = "statusChanged"
 
-	// EventAttestationCheckDone is fired when the the attestation signature check is completed. In
+	// EventAttestationCheckDone is fired when the attestation signature check is completed. In
 	// case of failure, the user should be alerted, before they enter the password.
 	EventAttestationCheckDone Event = "attestationCheckDone"
 )

--- a/communication/usart/usart_internal_test.go
+++ b/communication/usart/usart_internal_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package usart
 
 import (


### PR DESCRIPTION
This change is needed as GitHub deprecated ubuntu-18.04:

>  The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04 or ubuntu-22.04 (ubuntu-latest). For more details, see https://github.com/actions/runner-images/issues/6002