### PR TITLE
firmware/query: improve last usb query intervals log

### DIFF
--- a/api/firmware/query.go
+++ b/api/firmware/query.go
@@ -15,6 +15,7 @@
 package firmware
 
 import (
+	"container/ring"
 	"fmt"
 	"time"
 
@@ -54,7 +55,11 @@ const (
 func (device *Device) rawQueryV7(msg []byte) ([]byte, error) {
 	var status string
 	var payload []byte
+	// saving 11 timestamps to show the last 10 intervals.
+	lastQueryTimes := ring.New(11)
 	for {
+		lastQueryTimes.Value = time.Now()
+		lastQueryTimes = lastQueryTimes.Next()
 		responseBytes, err := device.communication.Query(append([]byte(hwwReqNew), msg...))
 		if err != nil {
 			return nil, err
@@ -70,8 +75,6 @@ func (device *Device) rawQueryV7(msg []byte) ([]byte, error) {
 		break
 	}
 
-	var lastQueryTime time.Time
-
 	for {
 		switch status {
 		case hwwRspAck:
@@ -79,18 +82,27 @@ func (device *Device) rawQueryV7(msg []byte) ([]byte, error) {
 		case hwwRspBusy:
 			return nil, errp.New("unexpected hwwRspBusy response")
 		case hwwRspNack:
-			if lastQueryTime.IsZero() {
+			lastQueryTimes = lastQueryTimes.Prev()
+			if lastQueryTimes.Prev().Value == nil {
 				device.log.Debug("unexpected NACK response in first loop iteration")
 			} else {
-				device.log.Debug(
-					fmt.Sprintf(
-						"unexpected NACK response; last successful query was %v ago",
-						time.Since(lastQueryTime)))
+				logStr := "unexpected NACK response; last successful retry query intervals (newest first) were: "
+				for i := 0; i < lastQueryTimes.Len()-1; i++ {
+					if lastQueryTimes.Value == nil || lastQueryTimes.Prev().Value == nil {
+						break
+					}
+					t := lastQueryTimes.Value
+					lastQueryTimes = lastQueryTimes.Prev()
+					tPrev := lastQueryTimes.Value
+					logStr += fmt.Sprintf("%v; ", t.(time.Time).Sub(tPrev.(time.Time)))
+				}
+				device.log.Debug(logStr)
 			}
 			return nil, errp.New("unexpected NACK response")
 		case hwwRspNotready:
-			lastQueryTime = time.Now()
 			time.Sleep(200 * time.Millisecond)
+			lastQueryTimes.Value = time.Now()
+			lastQueryTimes = lastQueryTimes.Next()
 			responseBytes, err := device.communication.Query([]byte(hwwReqRetry))
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The previous 'unexpected NACK response; last successful query..' log line wasn't really useful as it was logging the time between the last `hwwRspNotready` and the next (and last) `hwwRspNack` responses. We actually want to log the interval between the `hwwReqRetry` requests, that can cause the Nack response (if happening with more than 500ms delay).

With this change, we use a circular buffer and keep trace of the timing interval of the last 10 retry requests, to better investigate usb timing issues.