### PR TITLE
api/firmware/eth: parse eth eip-712 uints as hex

### DIFF
--- a/api/firmware/eth.go
+++ b/api/firmware/eth.go
@@ -389,7 +389,7 @@ func encodeValue(typ *messages.ETHSignTypedMessageRequest_MemberType, value inte
 	switch typ.Type {
 	case messages.ETHSignTypedMessageRequest_BYTES:
 		v := value.(string)
-		if len(v) >= 2 && v[:2] == "0x" {
+		if strings.HasPrefix(v, "0x") || strings.HasPrefix(v, "0X") {
 			return hex.DecodeString(v[2:])
 		}
 		return []byte(v), nil
@@ -397,9 +397,16 @@ func encodeValue(typ *messages.ETHSignTypedMessageRequest_MemberType, value inte
 		bigint := new(big.Int)
 		switch v := value.(type) {
 		case string:
-			_, ok := bigint.SetString(v, 10)
-			if !ok {
-				return nil, errp.Newf("couldn't parse uint: %s", v)
+			if strings.HasPrefix(v, "0x") || strings.HasPrefix(v, "0X") {
+				_, ok := bigint.SetString(v[2:], 16)
+				if !ok {
+					return nil, errp.Newf("couldn't parse uint: %s", v)
+				}
+			} else {
+				_, ok := bigint.SetString(v, 10)
+				if !ok {
+					return nil, errp.Newf("couldn't parse uint: %s", v)
+				}
 			}
 		case float64:
 			v64 := uint64(v)
@@ -417,7 +424,7 @@ func encodeValue(typ *messages.ETHSignTypedMessageRequest_MemberType, value inte
 		case string:
 			_, ok := bigint.SetString(v, 10)
 			if !ok {
-				return nil, errp.Newf("couldn't parse uint: %s", v)
+				return nil, errp.Newf("couldn't parse int: %s", v)
 			}
 		case float64:
 			v64 := int64(v)

--- a/api/firmware/eth_test.go
+++ b/api/firmware/eth_test.go
@@ -199,6 +199,10 @@ func TestEncodeValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("\xb1\xd8\x4b\x7c"), encoded)
 
+	encoded, err = encodeValue(parseTypeNoErr(t, "uint64", nil), "0xb1d84b7c")
+	require.NoError(t, err)
+	require.Equal(t, []byte("\xb1\xd8\x4b\x7c"), encoded)
+
 	encoded, err = encodeValue(parseTypeNoErr(t, "int64", nil), float64(2983742332))
 	require.NoError(t, err)
 	require.Equal(t, []byte("\xb1\xd8\x4b\x7c"), encoded)

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -226,7 +226,8 @@ func main() {
         ],
         "Person": [
             { "name": "name", "type": "string" },
-            { "name": "wallet", "type": "address" }
+            { "name": "wallet", "type": "address" },
+            { "name": "age", "type": "uint8" }
         ],
         "Mail": [
             { "name": "from", "type": "Person" },
@@ -245,11 +246,13 @@ func main() {
     "message": {
         "from": {
             "name": "Cow",
-            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+            "age": 20
         },
         "to": {
             "name": "Bob",
-            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+            "age": "0x1e"
         },
         "contents": "Hello, Bob!",
         "attachments": [{ "contents": "attachment1" }, { "contents": "attachment2" }]


### PR DESCRIPTION
Some apps use EIP-712 typed messages but provide uints in hex format instead of decimal format.