### PR TITLE
api/firmware/device: info use device status fields

### DIFF
--- a/api/firmware/backup.go
+++ b/api/firmware/backup.go
@@ -23,7 +23,7 @@ import (
 
 // CreateBackup is called after SetPassword() to create the backup.
 func (device *Device) CreateBackup() error {
-	if device.status != StatusSeeded && device.status != StatusInitialized {
+	if device.status != StatusSeeded && device.status != StatusUnlocked {
 		return errp.New("invalid status")
 	}
 
@@ -49,7 +49,7 @@ func (device *Device) CreateBackup() error {
 		return errp.New("unexpected response")
 	}
 	if device.status == StatusSeeded {
-		device.changeStatus(StatusInitialized)
+		device.changeStatus(StatusUnlocked)
 	}
 	return nil
 }
@@ -130,6 +130,6 @@ func (device *Device) RestoreBackup(id string) error {
 	if !ok {
 		return errp.New("unexpected response")
 	}
-	device.changeStatus(StatusInitialized)
+	device.changeStatus(StatusUnlocked)
 	return nil
 }

--- a/api/firmware/backup_test.go
+++ b/api/firmware/backup_test.go
@@ -38,7 +38,7 @@ func TestSimulatorBackups(t *testing.T) {
 		require.Error(t, err)
 
 		require.NoError(t, device.CreateBackup())
-		require.Equal(t, StatusInitialized, device.Status())
+		require.Equal(t, StatusUnlocked, device.Status())
 
 		list, err = device.ListBackups()
 		require.NoError(t, err)

--- a/api/firmware/mnemonic.go
+++ b/api/firmware/mnemonic.go
@@ -38,7 +38,7 @@ func (device *Device) ShowMnemonic() error {
 		return errp.New("unexpected response")
 	}
 	if device.status == StatusSeeded {
-		device.changeStatus(StatusInitialized)
+		device.changeStatus(StatusUnlocked)
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func (device *Device) RestoreFromMnemonic() error {
 	if !ok {
 		return errp.New("unexpected response")
 	}
-	device.changeStatus(StatusInitialized)
+	device.changeStatus(StatusUnlocked)
 	return nil
 }
 

--- a/api/firmware/pairing.go
+++ b/api/firmware/pairing.go
@@ -175,7 +175,7 @@ func (device *Device) ChannelHashVerify(ok bool) {
 			return
 		}
 		if info.Initialized {
-			device.changeStatus(StatusInitialized)
+			device.changeStatus(StatusUnlocked)
 		} else {
 			device.changeStatus(StatusUninitialized)
 		}

--- a/api/firmware/query.go
+++ b/api/firmware/query.go
@@ -37,7 +37,7 @@ const (
 	hwwReqRetry = "\x01"
 	// Cancel any outstanding request.
 	// hwwReqCancel = "\x02"
-	// INFO api call (used to be OP_INFO api call), graduated to the toplevel framing so it works
+	// REQ_INFO api call (used to be OP_INFO api call), graduated to the toplevel framing so it works
 	// the same way for all firmware versions.
 	hwwInfo = "i"
 

--- a/api/firmware/status.go
+++ b/api/firmware/status.go
@@ -24,7 +24,7 @@ const (
 	StatusConnected Status = "connected"
 
 	// StatusUnpaired means the pairing has not been confirmed yet. After the pairing screen has
-	// been confirmed, we move to StatusUninitialized or StatusInitialized depending on the device
+	// been confirmed, we move to StatusUninitialized or StatusUnlocked depending on the device
 	// status.
 	StatusUnpaired Status = "unpaired"
 
@@ -36,12 +36,12 @@ const (
 	StatusUninitialized Status = "uninitialized"
 
 	// StatusSeeded is after SetPassword(), before CreateBack() during initialization of the
-	// device. Use CreateBackup() to move to StatusInitialized.
+	// device. Use CreateBackup() to move to StatusUnlocked.
 	StatusSeeded Status = "seeded"
 
-	// StatusInitialized means the device is seeded and the backup was created, and the device is
+	// StatusUnlocked means the device is seeded and the backup was created, and the device is
 	// unlocked. The keystore is ready to use.
-	StatusInitialized Status = "initialized"
+	StatusUnlocked Status = "unlocked"
 
 	// StatusRequireFirmwareUpgrade means that the a firmware upgrade is required before being able
 	// to proceed to StatusLoggedIn or StatusSeeded (firmware version too old).

--- a/api/firmware/system.go
+++ b/api/firmware/system.go
@@ -87,7 +87,7 @@ func (device *Device) SetPassword(seedLen int) error {
 	if seedLen == 16 && !device.version.AtLeast(semver.NewSemVer(9, 6, 0)) {
 		return UnsupportedError("9.6.0")
 	}
-	if device.status == StatusInitialized {
+	if device.status == StatusUnlocked {
 		return errp.New("invalid status")
 	}
 	request := &messages.Request{


### PR DESCRIPTION
Return initialized status from info() and use unlocked and initialized to set the device status appropriately.

After firmware [PR 1229](https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1229)