### PR TITLE
tests: allow running integration tests against a custom simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ cp /path/to/bitbox02-firmware/messages/*.proto api/firmware/messages/
 rm api/firmware/messages/backup.proto
 ./api/firmware/messages/generate.sh
 ```
+
+## Simulator tests
+
+The `TestSimulator*` tests run integration against BitBox02 simulators. They are automatically
+downloaded based on [api/firmware/testdata/simulators.json](api/firmware/testdata/simulators.json),
+and each one is tested with.
+
+To run them, use:
+
+    go test -v -run TestSimulator ./...
+
+If you want to test against a custom simulator build (e.g. when developing new firmware features),
+you can run:
+
+    SIMULATOR=/path/to/simulator go test -v -run TestSimulator ./...
+
+In this case, only the given simulator will be used, and the ones defined in simulators.json will be
+ignored.

--- a/api/firmware/device_test.go
+++ b/api/firmware/device_test.go
@@ -168,8 +168,15 @@ func testSimulators(t *testing.T, run func(*testing.T, *Device)) {
 		t.Skip("Skipping simulator tests: not running on linux-amd64")
 	}
 
-	simulatorFilenames, err := downloadSimulatorsOnce()
-	require.NoError(t, err)
+	var simulatorFilenames []string
+	envSimulator := os.Getenv("SIMULATOR")
+	if envSimulator != "" {
+		simulatorFilenames = []string{envSimulator}
+	} else {
+		var err error
+		simulatorFilenames, err = downloadSimulatorsOnce()
+		require.NoError(t, err)
+	}
 
 	for _, simulatorFilename := range simulatorFilenames {
 		t.Run(filepath.Base(simulatorFilename), func(t *testing.T) {


### PR DESCRIPTION
For convenience. Useful to test simulators of upcoming firmware releases or local custom simulator builds.