### PR TITLE
PSBT

### DIFF
--- a/api/firmware/psbt.go
+++ b/api/firmware/psbt.go
@@ -1,0 +1,485 @@
+// Copyright 2025 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firmware
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
+	"github.com/BitBoxSwiss/bitbox02-api-go/util/errp"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"google.golang.org/protobuf/proto"
+)
+
+const HARDENED = 0x80000000
+
+// LeafHashes is guaranteed to have exactly one element.
+type taprootScript struct {
+	*psbt.TaprootBip32Derivation
+}
+
+// LeafHashes is guaranteed to be empty.
+type taprootInternal struct {
+	*psbt.TaprootBip32Derivation
+}
+
+type ourKey struct {
+	segwit          *psbt.Bip32Derivation
+	taprootInternal *taprootInternal
+	taprootScript   *taprootScript
+}
+
+// bip352Pubkey returns the pubkey used for silent payments:
+// - 33 byte compressed public key for p2pkh, p2wpkh, p2wpkh-p2sh.
+// - 32 byte x-only public key for p2tr
+// See https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki#user-content-Inputs_For_Shared_Secret_Derivation.
+func (key *ourKey) bip352Pubkey() ([]byte, error) {
+	if key.segwit != nil {
+		return key.segwit.PubKey, nil
+	}
+	if key.taprootInternal != nil {
+		pubKey, err := schnorr.ParsePubKey(key.taprootInternal.XOnlyPubKey)
+		if err != nil {
+			return nil, err
+		}
+		outputKey := txscript.ComputeTaprootKeyNoScript(pubKey)
+		return schnorr.SerializePubKey(outputKey), nil
+	}
+	return nil, errp.New("unsupported script type for silent payments")
+}
+
+func (key *ourKey) keypath() []uint32 {
+	if key.segwit != nil {
+		return key.segwit.Bip32Path
+	}
+	if key.taprootInternal != nil {
+		return key.taprootInternal.Bip32Path
+	}
+	return key.taprootScript.Bip32Path
+}
+
+type psbtInputInfo struct {
+	psbt.PInput
+}
+
+func (i psbtInputInfo) GetTapInternalKey() []byte {
+	return i.TaprootInternalKey
+}
+
+func (i psbtInputInfo) GetBip32Derivation() []*psbt.Bip32Derivation {
+	return i.Bip32Derivation
+}
+
+func (i psbtInputInfo) GetTaprootBip32Derivation() []*psbt.TaprootBip32Derivation {
+	return i.TaprootBip32Derivation
+}
+
+type psbtOutputInfo struct {
+	psbt.POutput
+}
+
+func (o psbtOutputInfo) GetTapInternalKey() []byte {
+	return o.TaprootInternalKey
+}
+
+func (o psbtOutputInfo) GetBip32Derivation() []*psbt.Bip32Derivation {
+	return o.Bip32Derivation
+}
+
+func (o psbtOutputInfo) GetTaprootBip32Derivation() []*psbt.TaprootBip32Derivation {
+	return o.TaprootBip32Derivation
+}
+
+type OutputInfo interface {
+	psbtInputInfo | psbtOutputInfo
+	GetBip32Derivation() []*psbt.Bip32Derivation
+	GetTapInternalKey() []byte
+	GetTaprootBip32Derivation() []*psbt.TaprootBip32Derivation
+}
+
+func findOurKey[O OutputInfo](ourRootFingerprint []byte, outputInfo O) (*ourKey, error) {
+	ourRootFingerPrintInt := binary.LittleEndian.Uint32(ourRootFingerprint)
+	for _, tapKey := range outputInfo.GetTaprootBip32Derivation() {
+		if ourRootFingerPrintInt == tapKey.MasterKeyFingerprint {
+			// TODO: check for fingerprint collision
+
+			if bytes.Equal(outputInfo.GetTapInternalKey(), tapKey.XOnlyPubKey) {
+				if len(tapKey.LeafHashes) > 0 {
+					return nil, errp.New("same key in internal key and in leaf script not allowed")
+				}
+				return &ourKey{taprootInternal: &taprootInternal{TaprootBip32Derivation: tapKey}}, nil
+			}
+			if len(tapKey.LeafHashes) != 1 {
+				return nil, errp.New("BIP-388 requires all pubkeys to be unique, but pubkeys is in multiple leaf scripts ")
+			}
+			return &ourKey{taprootScript: &taprootScript{TaprootBip32Derivation: tapKey}}, nil
+		}
+	}
+
+	for _, derivation := range outputInfo.GetBip32Derivation() {
+		if ourRootFingerPrintInt == derivation.MasterKeyFingerprint {
+			// TODO: check for fingerprint collision
+			return &ourKey{segwit: derivation}, nil
+		}
+	}
+	return nil, errp.New("key not found")
+}
+
+func scriptConfigFromUTXO(
+	utxo *wire.TxOut,
+	keypath []uint32,
+	redeemScript []byte,
+) (*messages.BTCScriptConfigWithKeypath, error) {
+	// Truncate to hardened prefix.
+	for i, el := range keypath {
+		if el < HARDENED {
+			keypath = keypath[:i]
+			break
+		}
+	}
+
+	if txscript.IsPayToWitnessPubKeyHash(utxo.PkScript) {
+		return &messages.BTCScriptConfigWithKeypath{
+			ScriptConfig: NewBTCScriptConfigSimple(messages.BTCScriptConfig_P2WPKH),
+			Keypath:      keypath,
+		}, nil
+	}
+
+	if txscript.IsPayToScriptHash(utxo.PkScript) && txscript.IsPayToWitnessPubKeyHash(redeemScript) {
+		return &messages.BTCScriptConfigWithKeypath{
+			ScriptConfig: NewBTCScriptConfigSimple(messages.BTCScriptConfig_P2WPKH_P2SH),
+			Keypath:      keypath,
+		}, nil
+	}
+
+	if txscript.IsPayToTaproot(utxo.PkScript) {
+		return &messages.BTCScriptConfigWithKeypath{
+			ScriptConfig: NewBTCScriptConfigSimple(messages.BTCScriptConfig_P2TR),
+			Keypath:      keypath,
+		}, nil
+	}
+	return nil, errp.New("unknown output type")
+}
+
+func payloadFromPkScript(pkScript []byte) (messages.BTCOutputType, []byte, error) {
+	var outputType messages.BTCOutputType
+	var payload []byte
+
+	switch {
+	case txscript.IsPayToPubKeyHash(pkScript):
+		outputType = messages.BTCOutputType_P2PKH
+		payload = pkScript[3:23]
+
+	case txscript.IsPayToScriptHash(pkScript):
+		outputType = messages.BTCOutputType_P2SH
+		payload = pkScript[2:22]
+
+	case txscript.IsPayToWitnessPubKeyHash(pkScript):
+		outputType = messages.BTCOutputType_P2WPKH
+		payload = pkScript[2:]
+
+	case txscript.IsPayToWitnessScriptHash(pkScript):
+		outputType = messages.BTCOutputType_P2WSH
+		payload = pkScript[2:]
+
+	case txscript.IsPayToTaproot(pkScript):
+		outputType = messages.BTCOutputType_P2TR
+		payload = pkScript[2:]
+
+	default:
+		return 0, nil, errp.New("unrecognized output type")
+	}
+
+	return outputType, payload, nil
+}
+
+// PSBTSignOutputOptions allows for providing output options beyond what is encoded in the PSBT.
+type PSBTSignOutputOptions struct {
+	// If not empty, this output's pkScript will be generated based on this silent payment address.
+	// The corresponding output pkScript in the PSBT's global unsigned tx
+	// (`PSBT_GLOBAL_UNSIGNED_TX`) will be populated during signing.
+	//
+	// A DLEQ proof verification is automatically performed during signing to verify the generated
+	// output is correct.
+	//
+	// Silent payments as part of PSBT is described in
+	// https://github.com/bitcoin/bips/blob/master/bip-0375.mediawiki, but we don't conform to that yet for two reasons:
+	// - it requires PSBTv2, while we only support PSBTv0 (see https://github.com/btcsuite/btcd/issues/2328)
+	// - BitBox02 silent payment support predates the BIP, and its DLEQ proof deviates from the one in the BIP.
+	SilentPaymentAddress string
+}
+
+// PSBTSignOptions allows for providing signing options beyond what is encoded in the PSBT.
+type PSBTSignOptions struct {
+	FormatUnit messages.BTCSignInitRequest_FormatUnit
+	// If ForceScriptConfig is nil, we attempt to infer the involved script configs. For the simple
+	// script config (single sig), we infer the script config from the involved
+	// pkScripts/redeemScripts.
+	//
+	// Multisig and policy configs are currently not inferred and must be provided using
+	// ForceScriptConfig.
+	ForceScriptConfig *messages.BTCScriptConfigWithKeypath
+	// Per-output options. The map key is the output index.
+	Outputs map[int]*PSBTSignOutputOptions
+}
+
+func (b *PSBTSignOptions) isSilentPayment() bool {
+	for _, output := range b.Outputs {
+		if output.SilentPaymentAddress != "" {
+			return true
+		}
+	}
+	return false
+}
+
+type psbtConvertResult struct {
+	tx            *BTCTx
+	ourKeys       []*ourKey
+	scriptConfigs []*messages.BTCScriptConfigWithKeypath
+}
+
+func newBTCTxFromPSBT(
+	psbt_ *psbt.Packet,
+	ourRootFingerprint []byte,
+	options *PSBTSignOptions) (*psbtConvertResult, error) {
+	if options == nil {
+		options = &PSBTSignOptions{}
+	}
+
+	isSilentPayment := options.isSilentPayment()
+
+	scriptConfigs := make([]*messages.BTCScriptConfigWithKeypath, 0)
+	if options.ForceScriptConfig != nil {
+		scriptConfigs = []*messages.BTCScriptConfigWithKeypath{options.ForceScriptConfig}
+	}
+
+	findOrAddScriptConfig := func(
+		txOut *wire.TxOut,
+		keypath []uint32,
+		redeemScript []byte) (uint32, error) {
+		if options.ForceScriptConfig != nil {
+			// Referncing scriptConfigs[0] above that is forced to `ForceScriptConfig`.
+			return 0, nil
+		}
+
+		// Infer script config from the PSBT input/output.
+		scriptConfig, err := scriptConfigFromUTXO(
+			txOut,
+			keypath,
+			redeemScript,
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		for i, cfg := range scriptConfigs {
+			if proto.Equal(cfg, scriptConfig) {
+				return uint32(i), nil
+			}
+		}
+		scriptConfigs = append(scriptConfigs, scriptConfig)
+		return uint32(len(scriptConfigs) - 1), nil
+	}
+
+	numInputs := len(psbt_.UnsignedTx.TxIn)
+	ourKeys := make([]*ourKey, numInputs)
+	inputs := make([]*BTCTxInput, numInputs)
+
+	for inputIndex, txInput := range psbt_.UnsignedTx.TxIn {
+		psbtInput := psbt_.Inputs[inputIndex]
+		prevOutPoint := txInput.PreviousOutPoint
+		var utxo *wire.TxOut
+		switch {
+		case psbtInput.WitnessUtxo != nil:
+			utxo = psbtInput.WitnessUtxo
+		case psbtInput.NonWitnessUtxo != nil:
+			utxo = psbtInput.NonWitnessUtxo.TxOut[prevOutPoint.Index]
+		default:
+			return nil, errp.Newf("could not find utxo of input %d", inputIndex)
+		}
+
+		ourKey, err := findOurKey(ourRootFingerprint, psbtInputInfo{psbtInput})
+		if err != nil {
+			return nil, err
+		}
+
+		scriptConfigIndex, err := findOrAddScriptConfig(
+			utxo,
+			ourKey.keypath(),
+			psbtInput.RedeemScript)
+		if err != nil {
+			return nil, err
+		}
+
+		var prevTx *BTCPrevTx
+		if psbtInput.NonWitnessUtxo != nil {
+			prevTx = NewBTCPrevTxFromBtcd(psbtInput.NonWitnessUtxo)
+		}
+
+		var bip352Pubkey []byte
+		if isSilentPayment {
+			bip352Pubkey, err = ourKey.bip352Pubkey()
+			if err != nil {
+				return nil, err
+			}
+
+		}
+
+		inputs[inputIndex] = &BTCTxInput{
+			Input: &messages.BTCSignInputRequest{
+				PrevOutHash:       prevOutPoint.Hash[:],
+				PrevOutIndex:      prevOutPoint.Index,
+				PrevOutValue:      uint64(utxo.Value),
+				Sequence:          txInput.Sequence,
+				Keypath:           ourKey.keypath(),
+				ScriptConfigIndex: scriptConfigIndex,
+			},
+			PrevTx:       prevTx,
+			BIP352Pubkey: bip352Pubkey,
+		}
+		ourKeys[inputIndex] = ourKey
+	}
+
+	numOutputs := len(psbt_.UnsignedTx.TxOut)
+	outputs := make([]*messages.BTCSignOutputRequest, numOutputs)
+
+	for outputIndex, txOutput := range psbt_.UnsignedTx.TxOut {
+		psbtOutput := psbt_.Outputs[outputIndex]
+
+		outputOptions := options.Outputs[outputIndex]
+
+		// Either change output or a non-change output owned by the BitBox.
+		if ourKey, err := findOurKey(ourRootFingerprint, psbtOutputInfo{psbtOutput}); err == nil {
+			scriptConfigIndex, err := findOrAddScriptConfig(
+				txOutput,
+				ourKey.keypath(),
+				psbtOutput.RedeemScript)
+			if err != nil {
+				return nil, err
+			}
+			outputs[outputIndex] = &messages.BTCSignOutputRequest{
+				Ours:              true,
+				Value:             uint64(txOutput.Value),
+				Keypath:           ourKey.keypath(),
+				ScriptConfigIndex: scriptConfigIndex,
+			}
+		} else {
+			var silentPayment *messages.BTCSignOutputRequest_SilentPayment
+			var outputType messages.BTCOutputType
+			var payload []byte
+			if outputOptions != nil && outputOptions.SilentPaymentAddress != "" {
+				silentPayment = &messages.BTCSignOutputRequest_SilentPayment{
+					Address: outputOptions.SilentPaymentAddress,
+				}
+			} else {
+				outputType, payload, err = payloadFromPkScript(txOutput.PkScript)
+				if err != nil {
+					return nil, err
+				}
+			}
+			outputs[outputIndex] = &messages.BTCSignOutputRequest{
+				Ours:          false,
+				Value:         uint64(txOutput.Value),
+				Type:          outputType,
+				Payload:       payload,
+				SilentPayment: silentPayment,
+			}
+		}
+	}
+
+	tx := &BTCTx{
+		Version:  uint32(psbt_.UnsignedTx.Version),
+		Inputs:   inputs,
+		Outputs:  outputs,
+		Locktime: psbt_.UnsignedTx.LockTime,
+	}
+
+	return &psbtConvertResult{
+		tx:            tx,
+		ourKeys:       ourKeys,
+		scriptConfigs: scriptConfigs,
+	}, nil
+}
+
+// Sign a PSBT. If `options` is nil, the default options are used. The PSBT input signatures will be
+// populated.
+func (device *Device) BTCSignPSBT(
+	coin messages.BTCCoin,
+	psbt_ *psbt.Packet,
+	options *PSBTSignOptions) error {
+
+	if options == nil {
+		options = &PSBTSignOptions{}
+	}
+
+	ourRootFingerprint, err := device.RootFingerprint()
+	if err != nil {
+		return err
+	}
+	txResult, err := newBTCTxFromPSBT(psbt_, ourRootFingerprint, options)
+	if err != nil {
+		return err
+	}
+	signResult, err := device.BTCSign(
+		coin, txResult.scriptConfigs, nil, txResult.tx, options.FormatUnit)
+	if err != nil {
+		return err
+	}
+
+	for inputIndex := range psbt_.Inputs {
+		psbtInput := &psbt_.Inputs[inputIndex]
+		signatureCompact := signResult.Signatures[inputIndex]
+		r := new(btcec.ModNScalar)
+		r.SetByteSlice(signatureCompact[:32])
+		s := new(btcec.ModNScalar)
+		s.SetByteSlice(signatureCompact[32:])
+		signatureDER := ecdsa.NewSignature(r, s).Serialize()
+		ourKey := txResult.ourKeys[inputIndex]
+		switch {
+		case ourKey.segwit != nil:
+			psbtInput.PartialSigs = []*psbt.PartialSig{
+				{
+					PubKey:    ourKey.segwit.PubKey,
+					Signature: append(signatureDER, byte(txscript.SigHashAll)),
+				},
+			}
+		case ourKey.taprootInternal != nil:
+			psbtInput.TaprootKeySpendSig = signatureCompact
+		case ourKey.taprootScript != nil:
+			psbtInput.TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{
+				{
+					XOnlyPubKey: ourKey.taprootScript.XOnlyPubKey,
+					LeafHash:    ourKey.taprootScript.LeafHashes[0],
+					Signature:   signatureCompact,
+					SigHash:     txscript.SigHashDefault,
+				},
+			}
+		default:
+			panic("unreachable")
+		}
+	}
+
+	for index, generatedOutput := range signResult.GeneratedOutputs {
+		psbt_.UnsignedTx.TxOut[index].PkScript = generatedOutput
+	}
+
+	return nil
+}

--- a/api/firmware/psbt_test.go
+++ b/api/firmware/psbt_test.go
@@ -1,0 +1,596 @@
+// Copyright 2025 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firmware
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
+	"github.com/BitBoxSwiss/bitbox02-api-go/util/errp"
+	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type psbtPrevoutFetcher struct {
+	psbt *psbt.Packet
+}
+
+// FetchPrevOutput implements `txscript.PrevOutputFetcher`.
+func (p psbtPrevoutFetcher) FetchPrevOutput(op wire.OutPoint) *wire.TxOut {
+	for inputIndex := range p.psbt.Inputs {
+		psbtInput := &p.psbt.Inputs[inputIndex]
+		txInput := p.psbt.UnsignedTx.TxIn[inputIndex]
+		if txInput.PreviousOutPoint.String() == op.String() {
+			if psbtInput.WitnessUtxo != nil {
+				return psbtInput.WitnessUtxo
+			}
+			if psbtInput.NonWitnessUtxo != nil {
+				return psbtInput.NonWitnessUtxo.TxOut[txInput.PreviousOutPoint.Index]
+			}
+		}
+	}
+	return nil
+}
+
+func txValidityCheck(psbt_ *psbt.Packet) error {
+	signedTx, err := psbt.Extract(psbt_)
+	if err != nil {
+		return err
+	}
+	prevOutputs := psbtPrevoutFetcher{psbt: psbt_}
+	sigHashes := txscript.NewTxSigHashes(signedTx, prevOutputs)
+	for index, txInput := range signedTx.TxIn {
+		spentOutput := prevOutputs.FetchPrevOutput(txInput.PreviousOutPoint)
+		engine, err := txscript.NewEngine(spentOutput.PkScript, signedTx, index,
+			txscript.StandardVerifyFlags, nil, sigHashes, spentOutput.Value, prevOutputs)
+		if err != nil {
+			return errp.WithStack(err)
+		}
+		if err := engine.Execute(); err != nil {
+			spew.Dump(err.(txscript.Error).ErrorCode)
+			return errp.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func TestPayloadFromPkScript(t *testing.T) {
+	tests := []struct {
+		name            string
+		address         string
+		expectedType    messages.BTCOutputType
+		expectedPayload string
+	}{
+		{
+			name:            "P2PKH",
+			address:         "1AMZK8xzHJWsuRErpGZTiW4jKz8fdfLUGE",
+			expectedPayload: "669c6cb1883c50a1b10c34bd1693c1f34fe3d798",
+			expectedType:    messages.BTCOutputType_P2PKH,
+		},
+		{
+			name:            "P2SH",
+			address:         "3JFL8CgtV4ZtMFYeP5LgV4JppLkHw5Gw9T",
+			expectedPayload: "b59e844a19063a882b3c34b64b941a8acdad74ee",
+			expectedType:    messages.BTCOutputType_P2SH,
+		},
+		{
+			name:            "P2WPKH",
+			address:         "bc1qkl8ms75cq6ajxtny7e88z3u9hkpkvktt5jwh6u",
+			expectedPayload: "b7cfb87a9806bb232e64f64e714785bd8366596b",
+			expectedType:    messages.BTCOutputType_P2WPKH,
+		},
+		{
+			name:            "P2WSH",
+			address:         "bc1q2fhgukymf0caaqrhfxrdju4wm94wwrch2ukntl5fuc0faz8zm49q0h6ss8",
+			expectedPayload: "526e8e589b4bf1de80774986d972aed96ae70f17572d35fe89e61e9e88e2dd4a",
+			expectedType:    messages.BTCOutputType_P2WSH,
+		},
+		{
+			name:            "P2TR",
+			address:         "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr",
+			expectedPayload: "a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c",
+			expectedType:    messages.BTCOutputType_P2TR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := btcutil.DecodeAddress(tt.address, &chaincfg.MainNetParams)
+			require.NoError(t, err)
+
+			pkScript, err := txscript.PayToAddrScript(addr)
+			require.NoError(t, err)
+
+			outputType, payload, err := payloadFromPkScript(pkScript)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedType, outputType)
+			assert.Equal(t, tt.expectedPayload, hex.EncodeToString(payload))
+		})
+	}
+}
+
+// Test that a PSBT containing only p2wpkh inputs is converted correctly to a transaction to be
+// signed by the BitBox.
+func TestNewBTCTxFromPSBT_P2WPKH(t *testing.T) {
+	// Based on mnemonic:
+	// route glue else try obey local kidney future teach unaware pulse exclude.
+	psbtStr := "cHNidP8BAHECAAAAAfbXTun4YYxDroWyzRq3jDsWFVlsZ7HUzxiORY/iR4goAAAAAAD9////AuLCAAAAAAAAFgAUg3w5W0zt3AmxRmgA5Q6wZJUDRhUowwAAAAAAABYAFJjQqUoXDcwUEqfExu9pnaSn5XBct0ElAAABAR+ghgEAAAAAABYAFHn03igII+hp819N2Zlb5LnN8atRAQDfAQAAAAABAZ9EJlMJnXF5bFVrb1eFBYrEev3pg35WpvS3RlELsMMrAQAAAAD9////AqCGAQAAAAAAFgAUefTeKAgj6GnzX03ZmVvkuc3xq1EoRs4JAAAAABYAFKG2PzjYjknaA6lmXFqPaSgHwXX9AkgwRQIhAL0v0r3LisQ9KOlGzMhM/xYqUmrv2a5sORRlkX1fqDC8AiB9XqxSNEdb4mPnp7ylF1cAlbAZ7jMhgIxHUXylTww3bwEhA0AEOM0yYEpexPoKE3vT51uxZ+8hk9sOEfBFKOeo6oDDAAAAACIGAyNQfmAT/YLmZaxxfDwClmVNt2BkFnfQu/i8Uc/hHDUiGBKiwYlUAACAAQAAgAAAAIAAAAAAAAAAAAAAIgIDnxFM7Qr9LvJwQDB9GozdTRIe3MYVuHOqT7dU2EuvHrIYEqLBiVQAAIABAACAAAAAgAEAAAAAAAAAAA=="
+
+	expectedTx := &BTCTx{
+		Version: 2,
+		Inputs: []*BTCTxInput{{
+			Input: &messages.BTCSignInputRequest{
+				PrevOutHash: []byte{
+					0xf6, 0xd7, 0x4e, 0xe9, 0xf8, 0x61, 0x8c, 0x43,
+					0xae, 0x85, 0xb2, 0xcd, 0x1a, 0xb7, 0x8c, 0x3b,
+					0x16, 0x15, 0x59, 0x6c, 0x67, 0xb1, 0xd4, 0xcf,
+					0x18, 0x8e, 0x45, 0x8f, 0xe2, 0x47, 0x88, 0x28,
+				},
+				PrevOutIndex:      0,
+				PrevOutValue:      100000,
+				Sequence:          0xfffffffd,
+				Keypath:           []uint32{84 + HARDENED, 1 + HARDENED, HARDENED, 0, 0},
+				ScriptConfigIndex: 0,
+			},
+			PrevTx: &BTCPrevTx{
+				Version: 1,
+				Inputs: []*messages.BTCPrevTxInputRequest{{
+					PrevOutHash: []byte{
+						0x9f, 0x44, 0x26, 0x53, 0x09, 0x9d, 0x71, 0x79,
+						0x6c, 0x55, 0x6b, 0x6f, 0x57, 0x85, 0x05, 0x8a,
+						0xc4, 0x7a, 0xfd, 0xe9, 0x83, 0x7e, 0x56, 0xa6,
+						0xf4, 0xb7, 0x46, 0x51, 0x0b, 0xb0, 0xc3, 0x2b,
+					},
+					PrevOutIndex:    1,
+					SignatureScript: []byte{},
+					Sequence:        0xfffffffd,
+				}},
+				Outputs: []*messages.BTCPrevTxOutputRequest{
+					{
+						Value: 100000,
+						PubkeyScript: []byte{
+							0x00, 0x14, 0x79, 0xf4, 0xde, 0x28, 0x08, 0x23,
+							0xe8, 0x69, 0xf3, 0x5f, 0x4d, 0xd9, 0x99, 0x5b,
+							0xe4, 0xb9, 0xcd, 0xf1, 0xab, 0x51,
+						},
+					},
+					{
+						Value: 164513320,
+						PubkeyScript: []byte{
+							0x00, 0x14, 0xa1, 0xb6, 0x3f, 0x38, 0xd8, 0x8e,
+							0x49, 0xda, 0x03, 0xa9, 0x66, 0x5c, 0x5a, 0x8f,
+							0x69, 0x28, 0x07, 0xc1, 0x75, 0xfd,
+						},
+					},
+				},
+				Locktime: 0,
+			},
+		}},
+		Outputs: []*messages.BTCSignOutputRequest{
+			{
+				Ours:  false,
+				Type:  messages.BTCOutputType_P2WPKH,
+				Value: 49890,
+				Payload: []byte{
+					0x83, 0x7c, 0x39, 0x5b, 0x4c, 0xed, 0xdc, 0x09,
+					0xb1, 0x46, 0x68, 0x00, 0xe5, 0x0e, 0xb0, 0x64,
+					0x95, 0x03, 0x46, 0x15,
+				},
+			},
+			{
+				Ours:              true,
+				Value:             49960,
+				Keypath:           []uint32{84 + HARDENED, 1 + HARDENED, HARDENED, 1, 0},
+				ScriptConfigIndex: 0,
+			},
+		},
+		Locktime: 2441655,
+	}
+
+	expectedScriptConfig := &messages.BTCScriptConfigWithKeypath{
+		ScriptConfig: NewBTCScriptConfigSimple(messages.BTCScriptConfig_P2WPKH),
+		Keypath:      []uint32{84 + HARDENED, 1 + HARDENED, HARDENED},
+	}
+
+	psbt_, err := psbt.NewFromRawBytes(bytes.NewBufferString(psbtStr), true)
+	require.NoError(t, err)
+	ourRootFingerprint := []byte{0x12, 0xa2, 0xc1, 0x89}
+	result, err := newBTCTxFromPSBT(psbt_, ourRootFingerprint, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedTx, result.tx)
+	assert.Len(t, result.scriptConfigs, 1)
+	require.True(t, proto.Equal(result.scriptConfigs[0], expectedScriptConfig))
+}
+
+func TestSimulatorBTCPSBTTaprootKeySpend(t *testing.T) {
+	testInitializedSimulators(t, func(t *testing.T, device *Device, stdOut *bytes.Buffer) {
+		t.Helper()
+
+		fingerprint, err := device.RootFingerprint()
+		require.NoError(t, err)
+
+		changePath := []uint32{86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 1, 0}
+		changePubKey := simulatorPub(t, device, changePath...)
+		_, changePkScript := makeTaprootOutput(t, changePubKey)
+
+		input0Path := []uint32{86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0}
+		input0Pubkey := simulatorPub(t, device, input0Path...)
+		_, input0PkScript := makeTaprootOutput(t, input0Pubkey)
+
+		input1Path := []uint32{86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 1}
+		input1PubKey := simulatorPub(t, device, input1Path...)
+		_, input1PkScript := makeTaprootOutput(t, input1PubKey)
+
+		// A previous tx which creates some UTXOs we can reference later.
+		prevTx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{
+				{
+					PreviousOutPoint: *mustOutpoint("3131313131313131313131313131313131313131313131313131313131313131:0"),
+					SignatureScript:  nil,
+					Sequence:         0xFFFFFFFF,
+					Witness:          nil,
+				},
+			},
+			TxOut: []*wire.TxOut{
+				{
+					Value:    100_000_000,
+					PkScript: input0PkScript,
+				},
+				{
+					Value:    100_000_000,
+					PkScript: input1PkScript,
+				},
+			},
+		}
+
+		tx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{
+				{
+					PreviousOutPoint: wire.OutPoint{
+						Hash:  prevTx.TxHash(),
+						Index: 0,
+					},
+					SignatureScript: nil,
+					Sequence:        0xFFFFFFFF,
+					Witness:         nil,
+				},
+				{
+					PreviousOutPoint: wire.OutPoint{
+						Hash:  prevTx.TxHash(),
+						Index: 1,
+					},
+					SignatureScript: nil,
+					Sequence:        0xFFFFFFFF,
+					Witness:         nil,
+				},
+			},
+			TxOut: []*wire.TxOut{
+				{
+					Value:    100_000_000,
+					PkScript: changePkScript,
+				},
+				{
+					Value: 20_000_000,
+					// random private key:
+					// 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+					PkScript: p2trPkScript(unhex("e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576")),
+				},
+			},
+		}
+		psbt_, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+
+		// Add input and change infos.
+		psbt_.Inputs[0].WitnessUtxo = prevTx.TxOut[0]
+		psbt_.Inputs[0].TaprootInternalKey = schnorr.SerializePubKey(input0Pubkey)
+		psbt_.Inputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Inputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input0Path,
+		}}
+
+		psbt_.Inputs[1].WitnessUtxo = prevTx.TxOut[1]
+		psbt_.Inputs[1].TaprootInternalKey = schnorr.SerializePubKey(input1PubKey)
+		psbt_.Inputs[1].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Inputs[1].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input1Path,
+		}}
+
+		psbt_.Outputs[0].TaprootInternalKey = schnorr.SerializePubKey(changePubKey)
+		psbt_.Outputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Outputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            changePath,
+		}}
+
+		// Sign & validate.
+		require.NoError(t, device.BTCSignPSBT(messages.BTCCoin_TBTC, psbt_, nil))
+		require.NoError(t, psbt.MaybeFinalizeAll(psbt_))
+		require.NoError(t, txValidityCheck(psbt_))
+	})
+}
+
+func TestSimulatorBTCPSBTMixedSpend(t *testing.T) {
+	testInitializedSimulators(t, func(t *testing.T, device *Device, stdOut *bytes.Buffer) {
+		t.Helper()
+
+		fingerprint, err := device.RootFingerprint()
+		require.NoError(t, err)
+
+		// Derivation paths
+		changePath := []uint32{86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 1, 0}
+		input0Path := []uint32{86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0} // P2TR
+		input1Path := []uint32{84 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0} // P2WPKH
+		input2Path := []uint32{49 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0} // P2SH-P2WPKH
+
+		// Generate public keys
+		input0Pub := simulatorPub(t, device, input0Path...)
+		input1Pub := simulatorPub(t, device, input1Path...)
+		input2Pub := simulatorPub(t, device, input2Path...)
+
+		// Convert to required formats
+		changePubKey := simulatorPub(t, device, changePath...)
+		_, changePkScript := makeTaprootOutput(t, changePubKey)
+		// P2WPKH redeem script
+		input2RedeemScript := p2wpkhPkScript(input2Pub)
+
+		// Previous transaction with mixed outputs
+		prevTx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: *mustOutpoint("3131313131313131313131313131313131313131313131313131313131313131:0"),
+				Sequence:         0xFFFFFFFF,
+			}},
+			TxOut: []*wire.TxOut{
+				{ // P2TR
+					Value: 100_000_000,
+					PkScript: func() []byte {
+						_, script := makeTaprootOutput(t, input0Pub)
+						return script
+					}(),
+				},
+				{ // P2WPKH
+					Value:    100_000_000,
+					PkScript: p2wpkhPkScript(input1Pub),
+				},
+				{ // P2SH-P2WPKH
+					Value:    100_000_000,
+					PkScript: p2shPkScript(input2RedeemScript),
+				},
+			},
+		}
+
+		// Spending transaction
+		tx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0}}, // P2TR input
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 1}}, // P2WPKH input
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 2}}, // P2SH-P2WPKH input
+			},
+			TxOut: []*wire.TxOut{
+				{ // Change output (P2TR)
+					Value:    100_000_000,
+					PkScript: changePkScript,
+				},
+				{ // External output
+					Value: 20_000_000,
+					// random private key:
+					// 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+					PkScript: p2trPkScript(unhex("e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576")),
+				},
+			},
+		}
+
+		psbt_, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+
+		// Setup PSBT inputs
+		// Input 0 (P2TR)
+		psbt_.Inputs[0].NonWitnessUtxo = prevTx
+		psbt_.Inputs[0].WitnessUtxo = prevTx.TxOut[0]
+		psbt_.Inputs[0].TaprootInternalKey = schnorr.SerializePubKey(changePubKey)
+		psbt_.Inputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Inputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input0Path,
+		}}
+
+		// Input 1 (P2WPKH)
+		psbt_.Inputs[1].NonWitnessUtxo = prevTx
+		psbt_.Inputs[1].WitnessUtxo = prevTx.TxOut[1]
+		psbt_.Inputs[1].Bip32Derivation = []*psbt.Bip32Derivation{{
+			PubKey:               input1Pub.SerializeCompressed(),
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input1Path,
+		}}
+
+		// Input 2 (P2SH-P2WPKH)
+		psbt_.Inputs[2].NonWitnessUtxo = prevTx
+		psbt_.Inputs[2].WitnessUtxo = prevTx.TxOut[2]
+		psbt_.Inputs[2].Bip32Derivation = []*psbt.Bip32Derivation{{
+			PubKey:               input2Pub.SerializeCompressed(),
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input2Path,
+		}}
+		psbt_.Inputs[2].RedeemScript = input2RedeemScript
+
+		// Setup change output
+		psbt_.Outputs[0].TaprootInternalKey = schnorr.SerializePubKey(changePubKey)
+		psbt_.Outputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Outputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            changePath,
+		}}
+
+		// Sign & validate
+		require.NoError(t, device.BTCSignPSBT(messages.BTCCoin_TBTC, psbt_, nil))
+		require.NoError(t, psbt.MaybeFinalizeAll(psbt_))
+		require.NoError(t, txValidityCheck(psbt_))
+	})
+}
+
+func TestSimulatorBTCPSBTSilentPayment(t *testing.T) {
+	testInitializedSimulators(t, func(t *testing.T, device *Device, stdOut *bytes.Buffer) {
+		t.Helper()
+
+		fingerprint, err := device.RootFingerprint()
+		require.NoError(t, err)
+
+		// Derivation paths
+		changePath := []uint32{86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1, 0}
+		input0Path := []uint32{86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0} // P2TR
+		input1Path := []uint32{84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0} // P2WPKH
+		input2Path := []uint32{49 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0} // P2SH-P2WPKH
+
+		// Generate public keys
+		input0Pub := simulatorPub(t, device, input0Path...)
+		input1Pub := simulatorPub(t, device, input1Path...)
+		input2Pub := simulatorPub(t, device, input2Path...)
+
+		// Convert to required formats
+		changePubKey := simulatorPub(t, device, changePath...)
+		_, changePkScript := makeTaprootOutput(t, changePubKey)
+		// P2WPKH redeem script
+		input2RedeemScript := p2wpkhPkScript(input2Pub)
+
+		// Previous transaction with mixed outputs
+		prevTx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: *mustOutpoint("3131313131313131313131313131313131313131313131313131313131313131:0"),
+				Sequence:         0xFFFFFFFF,
+			}},
+			TxOut: []*wire.TxOut{
+				{ // P2TR
+					Value: 100_000_000,
+					PkScript: func() []byte {
+						_, script := makeTaprootOutput(t, input0Pub)
+						return script
+					}(),
+				},
+				{ // P2WPKH
+					Value:    100_000_000,
+					PkScript: p2wpkhPkScript(input1Pub),
+				},
+				{ // P2SH-P2WPKH
+					Value:    100_000_000,
+					PkScript: p2shPkScript(input2RedeemScript),
+				},
+			},
+		}
+
+		// Spending transaction
+		tx := &wire.MsgTx{
+			Version:  2,
+			LockTime: 0,
+			TxIn: []*wire.TxIn{
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0}}, // P2TR input
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 1}}, // P2WPKH input
+				{PreviousOutPoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 2}}, // P2SH-P2WPKH input
+			},
+			TxOut: []*wire.TxOut{
+				{ // Change output (P2TR)
+					Value:    100_000_000,
+					PkScript: changePkScript,
+				},
+				{ // External output
+					Value: 20_000_000,
+					// Will be generated, silent payment output
+					PkScript: nil,
+				},
+			},
+		}
+
+		psbt_, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+
+		// Setup PSBT inputs
+		// Input 0 (P2TR)
+		psbt_.Inputs[0].NonWitnessUtxo = prevTx
+		psbt_.Inputs[0].WitnessUtxo = prevTx.TxOut[0]
+		psbt_.Inputs[0].TaprootInternalKey = schnorr.SerializePubKey(input0Pub)
+		psbt_.Inputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Inputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input0Path,
+		}}
+
+		// Input 1 (P2WPKH)
+		psbt_.Inputs[1].NonWitnessUtxo = prevTx
+		psbt_.Inputs[1].WitnessUtxo = prevTx.TxOut[1]
+		psbt_.Inputs[1].Bip32Derivation = []*psbt.Bip32Derivation{{
+			PubKey:               input1Pub.SerializeCompressed(),
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input1Path,
+		}}
+
+		// Input 2 (P2SH-P2WPKH)
+		psbt_.Inputs[2].NonWitnessUtxo = prevTx
+		psbt_.Inputs[2].WitnessUtxo = prevTx.TxOut[2]
+		psbt_.Inputs[2].Bip32Derivation = []*psbt.Bip32Derivation{{
+			PubKey:               input2Pub.SerializeCompressed(),
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            input2Path,
+		}}
+		psbt_.Inputs[2].RedeemScript = input2RedeemScript
+
+		// Setup change output
+		psbt_.Outputs[0].TaprootInternalKey = schnorr.SerializePubKey(changePubKey)
+		psbt_.Outputs[0].TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
+			XOnlyPubKey:          psbt_.Outputs[0].TaprootInternalKey,
+			MasterKeyFingerprint: binary.LittleEndian.Uint32(fingerprint),
+			Bip32Path:            changePath,
+		}}
+
+		// Sign & validate
+		signOptions := &PSBTSignOptions{
+			Outputs: map[int]*PSBTSignOutputOptions{
+				1: {
+					SilentPaymentAddress: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+				},
+			},
+		}
+		err = device.BTCSignPSBT(messages.BTCCoin_BTC, psbt_, signOptions)
+		if !device.version.AtLeast(semver.NewSemVer(9, 21, 0)) {
+			require.EqualError(t, err, UnsupportedError("9.21.0").Error())
+			return
+		}
+		require.NoError(t, err)
+		require.NoError(t, psbt.MaybeFinalizeAll(psbt_))
+		require.NoError(t, txValidityCheck(psbt_))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/btcsuite/btcd/btcutil/psbt v1.1.10 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUB
 github.com/btcsuite/btcd/btcutil v1.1.5/go.mod h1:PSZZ4UitpLBWzxGd5VGOrLnmOjtPP/a6HaFo12zMs00=
 github.com/btcsuite/btcd/btcutil v1.1.6 h1:zFL2+c3Lb9gEgqKNzowKUPQNb8jV7v5Oaodi/AYFd6c=
 github.com/btcsuite/btcd/btcutil v1.1.6/go.mod h1:9dFymx8HpuLqBnsPELrImQeTQfKBQqzqGbbV3jK55aE=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.10 h1:TC1zhxhFfhnGqoPjsrlEpoqzh+9TPOHrCgnPR47Mj9I=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.10/go.mod h1:ehBEvU91lxSlXtA+zZz3iFYx7Yq9eqnKx4/kSrnsvMY=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=


### PR DESCRIPTION
PSBT is the commonly supported format for handling Bitcoin transactions.

We use btcd's PSBT library, which currently supports PSBTv0 (BIP-174), and not yet PSBTv2 (BIP-370).

We add a `BTCSignPSBT()` function so third party wallets can more easily integrate this library, and so the BitBoxApp can start making use of PSBTs internally as well. Benefits include:

- well specified, so the concepts of which metadata goes where and is needed for what should be easier to understand and maintain

- consistency between client libs (bitbox02-api-go, bitbox-api-rs)

- can make use of btcd's PSBT library, which contains helper functions to update/sign/finalize a PSBT, so we can eliminate our own code to generate sigScripts/witnesses

Sign options are provided for custom modifications that are not encoded in the PSBT. We could also use PSBT proprietary fields for them, but that seems more annoying to deal with.