### PR TITLE
Add firmware simulator v9.26.3

### DIFF
--- a/api/firmware/backup_test.go
+++ b/api/firmware/backup_test.go
@@ -40,8 +40,11 @@ func TestSimulatorBackups(t *testing.T) {
 
 		require.Error(t, device.RestoreBackup(list[0].ID))
 
-		// v9.26.1 C simulator has a regression where the reset call loops forever.
-		if device.Version().String() != "9.26.1" {
+		// v9.26.1 and v9.26.3 C simulators have a regression where the reset call
+		// loops forever.
+		switch device.Version().String() {
+		case "9.26.1", "9.26.3":
+		default:
 			require.NoError(t, device.Reset())
 			require.NoError(t, device.RestoreBackup(list[0].ID))
 			id, err = device.CheckBackup(true)

--- a/api/firmware/testdata/simulators.json
+++ b/api/firmware/testdata/simulators.json
@@ -30,5 +30,9 @@
     {
         "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.26.1/bitbox02-multi-v9.26.1-simulator1.0.0-linux-amd64",
         "sha256": "91ddf47eb0653ce8b3d3344a8e329fc7fef90adfa51e39c5214830cf6e21cccf"
+    },
+    {
+        "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.26.3/bitbox02-multi-v9.26.3-simulator1.0.0-linux-amd64",
+        "sha256": "606e1fe6845430a47d1ecbda1df77a3b5e43a5dd164d2568431bbfdc882004dc"
     }
 ]


### PR DESCRIPTION
Add the v9.26.3 BitBox02 simulator release to the simulator test data.

The v9.26.3 simulator is based on v9.26.1 and inherits the C simulator reset hang.

Keep the backup reset test exception for both versions.